### PR TITLE
add vmware-exporter helm chart

### DIFF
--- a/components/component-deploy.sh
+++ b/components/component-deploy.sh
@@ -7,6 +7,7 @@ DEPLOY_S3_SYNCER="s3-syncer"
 DEPLOY_SGW="service-gateway"
 DEPLOY_CERT="cert-update-svc"
 DEPLOY_THANOS_SEED_INGRESS="thanos-seed-ingress"
+DEPLOY_VMWARE_EXPORTER="vmware-exporter"
 
 if [[ $# -lt 4 ]] || [[ "$1" == "--help" ]]; then
   echo "ARGUMENTS:"$*
@@ -69,6 +70,10 @@ case "$DEPLOY_STACK" in
 
   "$DEPLOY_THANOS_SEED_INGRESS")
     deploy thanos-seed-ingress monitoring thanos-seed-ingress
+    ;;
+    
+  "$DEPLOY_VMWARE_EXPORTER")
+    deploy vmware-exporter monitoring vmware-exporter
     ;;
   *)
     echo "error: no DEPLOY_STACK defined"

--- a/components/vmware-exporter/Chart.yaml
+++ b/components/vmware-exporter/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+name: vmware-exporter
+appVersion: v0.18.2
+description: VMware vCenter Exporter for Prometheus Helm chart
+home: https://github.com/pryorda/vmware_exporter
+maintainers:
+- name: The Kubermatic Kubernetes Platform contributors
+  email: support@kubermatic.com
+sources:
+- https://github.com/pryorda/vmware_exporter
+version: 2.2.0

--- a/components/vmware-exporter/templates/NOTES.txt
+++ b/components/vmware-exporter/templates/NOTES.txt
@@ -1,0 +1,14 @@
+1. Get vmware_exporter running using prometheus service discovery
+
+  Assure your Prometheus kubernetes_sd is configured to scrape the following pod annotations:
+
+  podAnnotations:
+ {{- range $k, $v := .Values.vmware-exporter.podAnnotations }}   
+    {{- if $v }}
+    - {{ $k }}: {{ $v | quote }}
+    {{- end }}
+ {{- end }}
+
+  Double check annotation names in source_labels match, your podAnnotations i.e. prometheus.io/scrape: "true"
+  annotation will result in checking the source label __meta_kubernetes_pod_annotation_prometheus_io_scrape
+

--- a/components/vmware-exporter/templates/_helpers.tpl
+++ b/components/vmware-exporter/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vmware-exporter.name" -}}
+{{- default .Chart.Name .Values.vmware-exporter.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "vmware-exporter.fullname" -}}
+{{- if .Values.vmware-exporter.fullnameOverride -}}
+{{- .Values.vmware-exporter.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.vmware-exporter.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "vmware-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/components/vmware-exporter/templates/configmap.yaml
+++ b/components/vmware-exporter/templates/configmap.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "vmware-exporter.fullname" . }}-config
+  labels:
+    app: {{ template "vmware-exporter.name" . }}
+    chart: {{ template "vmware-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  VSPHERE_USER: {{ .Values.vmware-exporter.vsphere.user | quote }}
+  VSPHERE_HOST: {{ .Values.vmware-exporter.vsphere.host | quote }}
+  VSPHERE_IGNORE_SSL: {{ .Values.vmware-exporter.vsphere.ignoressl | quote }}
+  VSPHERE_SPECS_SIZE: {{ .Values.vmware-exporter.vsphere.specsSize | quote }}
+  VSPHERE_FETCH_CUSTOM_ATTRIBUTES: {{ .Values.vmware-exporter.vsphere.fetchCustomAttributes | quote }}
+  VSPHERE_FETCH_TAGS: {{ .Values.vmware-exporter.vsphere.fetchTags | quote }}
+  VSPHERE_FETCH_ALARMS: {{ .Values.vmware-exporter.vsphere.fetchAlarms | quote }}
+  VSPHERE_COLLECT_HOSTS: {{ .Values.vmware-exporter.vsphere.collectors.hosts | quote }}
+  VSPHERE_COLLECT_DATASTORES: {{ default "True" .Values.vmware-exporter.vsphere.collectors.datastores | quote }}
+  VSPHERE_COLLECT_VMS: {{ .Values.vmware-exporter.vsphere.collectors.vms | quote }}
+  VSPHERE_COLLECT_VMGUESTS: {{ .Values.vmware-exporter.vsphere.collectors.vmguests | quote }}
+  VSPHERE_COLLECT_SNAPSHOTS: {{ .Values.vmware-exporter.vsphere.collectors.snapshots | quote }}
+{{- range $section := .Values.vmware-exporter.vsphere.sections }}
+{{- $key := $section.name }}
+  VSPHERE_{{ $key }}_USER: {{ $section.user | quote }}
+  VSPHERE_{{ $key }}_HOST: {{ $section.host | quote }}
+  VSPHERE_{{ $key }}_IGNORE_SSL: {{ $section.ignoressl | quote }}
+  {{- if $section.fetchCustomAttributes }}
+  VSPHERE_{{ $key }}_FETCH_CUSTOM_ATTRIBUTES: {{ $section.fetchCustomAttributes | quote }}
+  {{- end }}
+  {{- if $section.fetchTags }}
+  VSPHERE_{{ $key }}_FETCH_TAGS: {{ $section.fetchTags | quote }}
+  {{- end }}
+  {{- if $section.fetchAlarms }}
+  VSPHERE_{{ $key }}_FETCH_ALARMS: {{ $section.fetchAlarms | quote }}
+  {{- end }}
+{{- if $section.collectors }}
+  VSPHERE_{{ $key }}_COLLECT_HOSTS: {{ default $.Values.vmware-exporter.vsphere.collectors.hosts $section.collectors.hosts | quote }}
+  VSPHERE_{{ $key }}_COLLECT_DATASTORES: {{ default "True" $section.collectors.datastores | quote }}
+  VSPHERE_{{ $key }}_COLLECT_VMS: {{ default $.Values.vmware-exporter.vsphere.collectors.vms $section.collectors.vms | quote }}
+  VSPHERE_{{ $key }}_COLLECT_VMGUESTS: {{ default $.Values.vmware-exporter.vsphere.collectors.vmguests $section.collectors.vmguests | quote }}
+  VSPHERE_{{ $key }}_COLLECT_SNAPSHOTS: {{ default $.Values.vmware-exporter.vsphere.collectors.snapshots $section.collectors.snapshots | quote }}
+{{- end }}
+{{- end }}

--- a/components/vmware-exporter/templates/deployment.yaml
+++ b/components/vmware-exporter/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "vmware-exporter.fullname" . }}
+  labels:
+    app: {{ template "vmware-exporter.name" . }}
+    chart: {{ template "vmware-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.vmware-exporter.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "vmware-exporter.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "vmware-exporter.name" . }}
+        release: {{ .Release.Name }}
+      annotations:
+{{- with .Values.vmware-exporter.podAnnotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.vmware-exporter.image.repository }}:{{ .Values.vmware-exporter.image.tag }}"
+          imagePullPolicy: {{ .Values.vmware-exporter.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 9272
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ template "vmware-exporter.fullname" . }}-config
+            - secretRef:
+                name: {{ if not .Values.vmware-exporter.vsphere.existingSecret }}{{ template "vmware-exporter.fullname" . }}-secret{{ else }}{{ .Values.vmware-exporter.vsphere.existingSecret }}{{ end }}
+          livenessProbe:
+{{ toYaml .Values.vmware-exporter.livenessProbe | indent 12 }}
+          readinessProbe:
+{{ toYaml .Values.vmware-exporter.readinessProbe | indent 12 }}
+          resources:
+{{ toYaml .Values.vmware-exporter.resources | indent 12 }}
+        {{- with .Values.vmware-exporter.securityContext }}
+          securityContext:
+        {{- toYaml . | nindent 12 }}
+        {{- end }}
+    {{- with .Values.vmware-exporter.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.vmware-exporter.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.vmware-exporter.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.vmware-exporter.podSecurityContext }}
+      securityContext:
+    {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/components/vmware-exporter/templates/ingress.yaml
+++ b/components/vmware-exporter/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.vmware-exporter.ingress.enabled -}}
+{{- $fullName := include "vmware-exporter.fullname" . -}}
+{{- $servicePort := .Values.vmware-exporter.service.port -}}
+{{- $ingressPath := .Values.vmware-exporter.ingress.path -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "vmware-exporter.name" . }}
+    chart: {{ template "vmware-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.vmware-exporter.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.vmware-exporter.ingress.tls }}
+  tls:
+  {{- range .Values.vmware-exporter.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.vmware-exporter.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+  {{- end }}
+{{- end }}

--- a/components/vmware-exporter/templates/secret.yaml
+++ b/components/vmware-exporter/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{- if not .Values.vmware-exporter.vsphere.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "vmware-exporter.fullname" . }}-secret
+  labels:
+    app: {{ template "vmware-exporter.name" . }}
+    chart: {{ template "vmware-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  VSPHERE_PASSWORD: {{ default "" .Values.vmware-exporter.vsphere.password | b64enc | quote }}
+{{- range $section := .Values.vmware-exporter.vsphere.sections }}
+{{- $key := $section.name }}
+  VSPHERE_{{ $key }}_PASSWORD: {{ $section.password | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/components/vmware-exporter/templates/service.yaml
+++ b/components/vmware-exporter/templates/service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.vmware-exporter.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vmware-exporter.fullname" . }}
+  labels:
+    app: {{ template "vmware-exporter.name" . }}
+    chart: {{ template "vmware-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.vmware-exporter.service.annotations }} 
+  annotations: 
+{{ toYaml . | indent 4 }} 
+{{- end }} 
+spec:
+  type: {{ .Values.vmware-exporter.service.type }}
+  ports:
+    - port: {{ .Values.vmware-exporter.service.port }}
+      targetPort: {{ .Values.vmware-exporter.service.targetport }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "vmware-exporter.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/components/vmware-exporter/values.yaml
+++ b/components/vmware-exporter/values.yaml
@@ -1,0 +1,102 @@
+
+vmware-exporter:
+
+  replicaCount: 2
+  
+  vsphere:
+    user: user
+    password: na
+    existingSecret: {}
+    host: vcenter
+    ignoressl: true
+    fetchCustomAttributes: true
+    fetchTags: true
+    fetchAlarms: true
+    specsSize: 5000
+    sections: {}
+    collectors:
+      hosts: true
+      datastores: true
+      vms: true
+      vmguests: true
+      snapshots: true
+  
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9272"
+    prometheus.io/path: "/metrics"
+  
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: 9272
+  
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: 9272
+    initialDelaySeconds: 30
+    failureThreshold: 10
+  
+  image:
+    repository: pryorda/vmware_exporter
+    tag: v0.18.2
+    pullPolicy: IfNotPresent
+  
+  service:
+    enabled: false
+    type: ClusterIP
+    ## Provide optional annotations to the service i.e. for external-dns
+    # annotations:
+    ##   external-dns.alpha.kubernetes.io/hostname: yourservicename.k8s.yourcompany.com
+    ##
+    port: 80
+    targetport: 9272
+  
+  ingress:
+    enabled: false
+    annotations:
+      {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    path: /
+    hosts:
+      - chart-example.local
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+  
+  resources:
+    {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+  
+  nodeSelector: {}
+  
+  tolerations: []
+  
+  affinity: {}
+  
+  # Set the container security context
+  securityContext:
+    {}
+    #  capabilities:
+    #    drop: [ALL]
+    #  readOnlyRootFilesystem: true
+    #  runAsGroup: 65532
+    #  runAsNonRoot: true
+    #  runAsUser: 65532
+  
+  # Set the Pod security context
+  podSecurityContext:
+    {}
+    #  fsGroup: 65532


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:  To add basic monitoring of vsphere provider. This PR adds a chart named vmware-exporter, which adds metrics for Prometheus. According to the upstream chart below information will be get.

Basic VM and Host metrics
Current number of active snapshots
Datastore size and other stuff
Snapshot Unix timestamp creation date

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
