### PR TITLE
add s3/s3-dbdump-syncer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Name|Description
 [logging/audit/static-audit-log](components/logging/audit/static-audit-log) | Description how static audit logging could get configured
 [vm-images/packer-ubuntu1804-vsphere-template](./components/vm-images/packer-ubuntu1804-vsphere-template)|A packer template to customize an ubuntu 18.04 cloud-image on vSphere
 [s3/s3-syncer-aws-cli](./components/s3/s3-syncer-aws-cli) | s3-syncer based CronJob on the `aws s3` cli to sync two different S3 locations as well Azure (by Minio Azure Gateway)
+[s3/s3-dbdump-syncer](./components/s3/s3-dbdump-syncer) | s3-syncer based CronJob creates a DB dump of a postgres SQL database and sync it via the `aws s3` cli to a target S3 location.
 
 ## Kubermatic Example Setups
 

--- a/components/s3/s3-dbdump-syncer/Chart.yaml
+++ b/components/s3/s3-dbdump-syncer/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: s3-dbdump-syncer
+description: DB dumper and s3-syncer based on the `aws s3` cli
+version: 0.1.0
+type: application
+appVersion: 2.2.13
+keywords:
+  - kubermatic
+  - minio
+  - s3
+  - aws
+  - postgresql
+  - db
+maintainers:
+  - name: Kubermatic GmbH
+    email: ps@kubermatic.com

--- a/components/s3/s3-dbdump-syncer/templates/backup-and-sync.job.yaml
+++ b/components/s3/s3-dbdump-syncer/templates/backup-and-sync.job.yaml
@@ -29,7 +29,7 @@ spec:
               key: node-role.kubernetes.io/master
           initContainers:
             - name: sql-dumper
-              image: docker.io/bitnami/postgresql:11.13.0-debian-10-r60
+              image: {{ .Values.s3DBdumpSyncer.db.dumper.image.repository }}:{{ .Values.s3DBdumpSyncer.db.dumper.image.tag }}
               securityContext:
                 runAsGroup: 1001
               command:

--- a/components/s3/s3-dbdump-syncer/templates/backup-and-sync.job.yaml
+++ b/components/s3/s3-dbdump-syncer/templates/backup-and-sync.job.yaml
@@ -1,0 +1,104 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels:
+    job: s3-dbdump-syncer
+  name: s3-dbdump-syncer
+spec:
+  schedule: "{{ .Values.s3DBdumpSyncer.cron.schedule }}"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      labels:
+        job: s3-dbdump-syncer
+    spec:
+      activeDeadlineSeconds: 7200
+      backoffLimit: 5
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            job: s3-dbdump-syncer
+        spec:
+          terminationGracePeriodSeconds: 10
+          restartPolicy: Never
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/master
+          initContainers:
+            - name: sql-dumper
+              image: docker.io/bitnami/postgresql:11.13.0-debian-10-r60
+              securityContext:
+                runAsGroup: 1001
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  source /config/env
+                  set -Eeuo pipefail
+                  trap "echo 'error occured, sleep for 60 sec!'; sleep 60" ERR
+
+                  echo "----- start dump of SQL DATABAES: $(date) ---------"
+                  echo "USER: $(id -u)"
+                  ls -lah /data/
+                  echo "----- dump of $PGDATABASE ---------"
+                  pg_dump -f /data/$DB_DUMP_NAME
+                  echo "----- dump finished ---------"
+              volumeMounts:
+              - mountPath: /config
+                name: db-config
+                readOnly: true
+              - mountPath: /data
+                readOnly: false
+                name: tmp-data-vol
+          containers:
+          - image: {{ .Values.s3DBdumpSyncer.s3.image.repository }}:{{ .Values.s3DBdumpSyncer.s3.image.tag }}
+            imagePullPolicy: IfNotPresent
+            name: aws-client
+            resources:
+              limits:
+                cpu: 500m
+                memory: 500Mi
+            volumeMounts:
+              - mountPath: /config
+                name: s3-config
+                readOnly: true
+              - mountPath: /data
+                name: tmp-data-vol
+            command:
+              - /bin/bash
+              - -c
+              - |
+                source /config/env
+                set -Eeuo pipefail
+                trap "echo 'error occured, sleep for 60 sec!'; sleep 60" ERR
+
+                mkdir ~/.aws && cp /config/* ~/.aws/
+                export AWS_EC2_METADATA_DISABLED=true
+
+                if [[ "$TARGET_RENAME_CHAR" == true ]]; then
+                echo --- REMOVE incompatible char ':' ----------
+                for file in $(find /data/ -type f); do mv -v "${file}" "${file//:/-}" || true ; done
+                echo --------------------------
+                fi
+
+                echo --- upload to target -----
+                aws s3 --profile target $TARGET_SSL_VERIFY_FLAG --endpoint-url $TARGET_URL sync --delete /data/ s3://$TARGET_BUCKET/
+                echo --------------------------
+                echo --- SYNC JOB FINISHED ----
+                echo --------- target ---------
+                aws s3 --profile target $TARGET_SSL_VERIFY_FLAG --endpoint-url $TARGET_URL ls s3://$TARGET_BUCKET
+                echo --------------------------
+          volumes:
+            - name: s3-config
+              secret:
+                secretName: s3-config
+            - name: db-config
+              secret:
+                secretName: db-config
+            - name: tmp-data-vol
+              persistentVolumeClaim:
+                readOnly: false
+                claimName: s3-syncer-transfer-storage

--- a/components/s3/s3-dbdump-syncer/templates/credentials.db.secret.yaml
+++ b/components/s3/s3-dbdump-syncer/templates/credentials.db.secret.yaml
@@ -12,4 +12,4 @@ stringData:
     export PGPORT={{ .Values.s3DBdumpSyncer.db.postgresql.port }}
     export PGUSER={{ .Values.s3DBdumpSyncer.db.postgresql.user }}
     export PGPASSWORD={{ .Values.s3DBdumpSyncer.db.postgresql.pw }}
-    export DB_DUMP_NAME={{ .Values.s3DBdumpSyncer.db.dump.filename }}
+    export DB_DUMP_NAME={{ .Values.s3DBdumpSyncer.db.dumper.filename }}

--- a/components/s3/s3-dbdump-syncer/templates/credentials.db.secret.yaml
+++ b/components/s3/s3-dbdump-syncer/templates/credentials.db.secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    job: s3-db-dump-syncer
+  name: db-config
+stringData:
+  env: |-
+    export PGDATABASE={{ .Values.s3DBdumpSyncer.db.postgresql.database }}
+    export PGHOST={{ .Values.s3DBdumpSyncer.db.postgresql.host }}
+    export PGOPTIONS={{ .Values.s3DBdumpSyncer.db.postgresql.options }}
+    export PGPORT={{ .Values.s3DBdumpSyncer.db.postgresql.port }}
+    export PGUSER={{ .Values.s3DBdumpSyncer.db.postgresql.user }}
+    export PGPASSWORD={{ .Values.s3DBdumpSyncer.db.postgresql.pw }}
+    export DB_DUMP_NAME={{ .Values.s3DBdumpSyncer.db.dump.filename }}

--- a/components/s3/s3-dbdump-syncer/templates/credentials.s3-secret.yaml
+++ b/components/s3/s3-dbdump-syncer/templates/credentials.s3-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    job: s3-db-dump-syncer
+  name: s3-config
+stringData:
+  env: |-
+    export TARGET_URL={{ required "A valid .Values.s3DBdumpSyncer.s3.target.url entry required!" .Values.s3DBdumpSyncer.s3.target.url }}
+    export TARGET_BUCKET={{ .Values.s3DBdumpSyncer.s3.target.bucket }}
+    export TARGET_SSL_VERIFY_FLAG={{ if eq .Values.s3DBdumpSyncer.s3.target.insecure_skip_verify true }}--no-verify-ssl{{- end }}
+    export TARGET_RENAME_CHAR={{ .Values.s3DBdumpSyncer.s3.target.renameChar }}
+  credentials: |
+    [target]
+    aws_access_key_id={{ required "A valid .Values.s3DBdumpSyncer.s3.target.accessKey entry required!" .Values.s3DBdumpSyncer.s3.target.accessKey }}
+    aws_secret_access_key={{ required "A valid .Values.s3DBdumpSyncer.s3.target.secretKey entry required!" .Values.s3DBdumpSyncer.s3.target.secretKey }}
+    {{- if .Values.s3DBdumpSyncer.s3.target.ca_bundle }}
+    ca_bundle=~/.aws/ca_bundle_target.pem
+    {{- end }}
+{{- if .Values.s3DBdumpSyncer.s3.target.ca_bundle }}
+  ca_bundle_target.pem: |-
+{{ .Values.s3DBdumpSyncer.s3.target.ca_bundle | indent 4 }}
+{{- end }}

--- a/components/s3/s3-dbdump-syncer/templates/pvc.transfer.data.yaml
+++ b/components/s3/s3-dbdump-syncer/templates/pvc.transfer.data.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: s3-syncer-transfer-storage
+  labels:
+    job: s3-db-dump-syncer
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.s3DBdumpSyncer.storage.size }}
+  {{- if .Values.s3DBdumpSyncer.storage.class }}
+  storageClassName: {{ .Values.s3DBdumpSyncer.storage.class }}
+  {{- end }}

--- a/components/s3/s3-dbdump-syncer/values.yaml
+++ b/components/s3/s3-dbdump-syncer/values.yaml
@@ -5,7 +5,10 @@ s3DBdumpSyncer:
     size: 100Gi
     class: ''
   db:
-    dump:
+    dumper:
+      image:
+        repository: docker.io/bitnami/postgresql
+        tag: 11.13.0-debian-10-r60
       filename: db-dump.sql
     postgresql:
       host: 'postgresql'

--- a/components/s3/s3-dbdump-syncer/values.yaml
+++ b/components/s3/s3-dbdump-syncer/values.yaml
@@ -1,0 +1,33 @@
+s3DBdumpSyncer:
+  cron:
+    schedule: '*/30 * * * *'
+  storage:
+    size: 100Gi
+    class: ''
+  db:
+    dump:
+      filename: db-dump.sql
+    postgresql:
+      host: 'postgresql'
+      port: 5432
+      database: 'test'
+      user: 'postgres'
+      pw: 'password'
+      options: ''
+  s3:
+    image:
+      repository: docker.io/amazon/aws-cli
+      tag: 2.2.13
+    target:
+      # These settings are required. Keys must be alphanumeric.
+      url: "https://s3.amazonaws.com"
+      bucket: ''
+      accessKey: '' # 32 byte long
+      secretKey: '' # 64 byte long
+      insecure_skip_verify: false
+      renameChar: false
+      ca_bundle: ''
+  #    ca_bundle: |-
+  #      -----BEGIN CERTIFICATE-----
+  #      xxxxxxxx EXAMPLE xxxxxxxxxx
+  #      -----END CERTIFICATE-----


### PR DESCRIPTION
s3-syncer based CronJob creates a DB dump of a postgres SQL database and sync it via the `aws s3` cli to a target S3 location.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
```
