### PR TITLE
add option to use ssh repos too

### DIFF
--- a/kubermatic-addons/addon-manifests/argocd.yaml
+++ b/kubermatic-addons/addon-manifests/argocd.yaml
@@ -6,7 +6,7 @@ spec:
   description: Declarative continuous deployment for Kubernetes (as high availability installation).
   formSpec:
       - displayName: Git repository URL
-        helpText: URL of the Git repository used as source (only HTTP/S URLs are currently supported)
+        helpText: URL of the Git repository used as source (HTTP/S w/ username+password or SSH w/ your private key)
         internalName: gitRepositoryUrl
         required: true
         type: text
@@ -30,6 +30,11 @@ spec:
         internalName: gitRepositoryHttpPassword
         required: false
         type: text
+      - displayName: SSH Private Key
+        helpText: Please provide SSH Private Key if you use a SSH-RepoURL (leave username and password empty in this case)
+        internalName: gitRepositorySshPrivateKey
+        required: false
+        type: text-area
       - displayName: ArgoCD container image
         helpText: Container image used for all ArgoCD components (defaults to "quay.io/argoproj/argocd:v2.1.7")
         internalName: argoContainerImage

--- a/kubermatic-addons/custom-addon/argocd/01-bootstrap.yaml
+++ b/kubermatic-addons/custom-addon/argocd/01-bootstrap.yaml
@@ -13,6 +13,10 @@ data:
   password: {{ .Variables.gitRepositoryHttpPassword | b64enc | quote }}
   username: {{ .Variables.gitRepositoryHttpUsername | b64enc | quote }}
   {{- end }}
+  {{- if .Variables.gitRepositorySshPrivateKey }}
+  sshPrivateKey: |
+      {{ .Variables.gitRepositorySshPrivateKey | b64enc }}
+  {{- end }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application


### PR DESCRIPTION
Signed-off-by: Johann Grabmann <johann@grabmann.eu>

**What this PR does / why we need it**:
Added an option to also use SSH-Repos with an SSH private Key instead of HTTP(S) with username and password

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

