### PR TITLE
Add SSH support to ArgoCD addon

### DIFF
--- a/kubermatic-addons/addon-manifests/argocd.yaml
+++ b/kubermatic-addons/addon-manifests/argocd.yaml
@@ -6,7 +6,7 @@ spec:
   description: Declarative continuous deployment for Kubernetes (as high availability installation).
   formSpec:
       - displayName: Git repository URL
-        helpText: URL of the Git repository used as source (HTTP/S w/ username+password or SSH w/ your private key)
+        helpText: URL of the Git repository used as source (HTTP/S with username/password or SSH with SSH private key)
         internalName: gitRepositoryUrl
         required: true
         type: text
@@ -30,9 +30,14 @@ spec:
         internalName: gitRepositoryHttpPassword
         required: false
         type: text
-      - displayName: SSH Private Key
-        helpText: Please provide SSH Private Key if you use a SSH-RepoURL (leave username and password empty in this case)
+      - displayName: SSH private key
+        helpText: SSH private key used to access the Git repository
         internalName: gitRepositorySshPrivateKey
+        required: false
+        type: text-area
+      - displayName: SSH known hosts
+        helpText: Initial SSH known host entries added to ArgoCD (if there are already existing SSH known host entries, this value has no effect)
+        internalName: initialSshKnownHosts
         required: false
         type: text-area
       - displayName: ArgoCD container image

--- a/kubermatic-addons/addon-manifests/argocd.yaml
+++ b/kubermatic-addons/addon-manifests/argocd.yaml
@@ -6,7 +6,7 @@ spec:
   description: Declarative continuous deployment for Kubernetes (as high availability installation).
   formSpec:
       - displayName: Git repository URL
-        helpText: URL of the Git repository used as source (only HTTP/S URLs are currently supported)
+        helpText: URL of the Git repository used as source (HTTP/S w/ username+password or SSH w/ your private key)
         internalName: gitRepositoryUrl
         required: true
         type: text
@@ -30,6 +30,11 @@ spec:
         internalName: gitRepositoryHttpPassword
         required: false
         type: text
+      - displayName: SSH Private Key
+        helpText: Please provide SSH Private Key if you use a SSH-RepoURL (leave username and password empty in this case)
+        internalName: gitRepositorySshPrivateKey
+        required: false
+        type: text-area
       - displayName: ArgoCD container image
         helpText: Container image used for all ArgoCD components (defaults to "quay.io/argoproj/argocd:v2.1.7")
         internalName: argoContainerImage

--- a/kubermatic-addons/custom-addon/argocd/00-manifest.yaml
+++ b/kubermatic-addons/custom-addon/argocd/00-manifest.yaml
@@ -4394,6 +4394,38 @@ spec:
               fieldPath: metadata.namespace
         image: '{{ Registry "docker.io" }}/bitnami/kubectl:{{ .Cluster.MajorMinorVersion }}'
         name: init-configmaps
+{{- if .Variables.initialSshKnownHosts }}
+      - command:
+        - /bin/bash
+        - -c
+        - |
+          #!/usr/bin/env bash
+
+          set -euo pipefail
+
+          configmap="argocd-ssh-known-hosts-cm"
+          key="ssh_known_hosts"
+
+          echo "Ensuring configmap ${configmap} exists and does not contain key ${key}..."
+          if kubectl --namespace="${RUNTIME_NAMESPACE}" get configmap "${configmap}" &> /dev/null; then
+            if [ -z "$(kubectl --namespace="${RUNTIME_NAMESPACE}" get configmap "${configmap}" -o jsonpath='{.data.ssh_known_hosts}')" ]; then
+              echo "Adding initial SSH known hosts entries to configmap ${configmap}..."
+              kubectl --namespace="${RUNTIME_NAMESPACE}" patch configmap "${configmap}" --patch="$(cat <<- EOF
+                data:
+                  ${key}: |
+                    {{- .Variables.initialSshKnownHosts | nindent 20 }}
+          EOF
+          )"
+            fi
+          fi
+        env:
+        - name: RUNTIME_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: '{{ Registry "docker.io" }}/bitnami/kubectl:{{ .Cluster.MajorMinorVersion }}'
+        name: init-ssh-known-hosts
+{{- end }}
       serviceAccountName: argocd-application-controller
       volumes:
       - emptyDir: {}

--- a/kubermatic-addons/custom-addon/argocd/01-bootstrap.yaml
+++ b/kubermatic-addons/custom-addon/argocd/01-bootstrap.yaml
@@ -13,6 +13,10 @@ data:
   password: {{ .Variables.gitRepositoryHttpPassword | b64enc | quote }}
   username: {{ .Variables.gitRepositoryHttpUsername | b64enc | quote }}
   {{- end }}
+  {{- if .Variables.gitRepositorySshPrivateKey }}
+  sshPrivateKey: |
+      {{ .Variables.gitRepositorySshPrivateKey | b64enc }}
+  {{- end }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/kubermatic-addons/kustomize/argocd/kustomization.yaml
+++ b/kubermatic-addons/kustomize/argocd/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
 
 patchesStrategicMerge:
   - patches/delete-dynamic-configmaps.yaml
+  - patches/add-ssh-known-hosts-init-container.yaml
   - patches/add-configmap-init-container.yaml

--- a/kubermatic-addons/kustomize/argocd/patches/add-ssh-known-hosts-init-container.yaml
+++ b/kubermatic-addons/kustomize/argocd/patches/add-ssh-known-hosts-init-container.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: argocd-application-controller
+spec:
+  template:
+    spec:
+      initContainers:
+        - image: bitnami/kubectl:1.22
+          command:
+            - /bin/bash
+            - -c
+            - |
+              #!/usr/bin/env bash
+
+              set -euo pipefail
+
+              configmap="argocd-ssh-known-hosts-cm"
+              key="ssh_known_hosts"
+
+              echo "Ensuring configmap ${configmap} exists and does not contain key ${key}..."
+              if kubectl --namespace="${RUNTIME_NAMESPACE}" get configmap "${configmap}" &> /dev/null; then
+                if [ -z "$(kubectl --namespace="${RUNTIME_NAMESPACE}" get configmap "${configmap}" -o jsonpath='{.data.ssh_known_hosts}')" ]; then
+                  echo "Adding initial SSH known hosts entries to configmap ${configmap}..."
+                  kubectl --namespace="${RUNTIME_NAMESPACE}" patch configmap "${configmap}" --patch="$(cat <<- EOF
+                    data:
+                      ${key}: |
+                        {{- .Variables.initialSshKnownHosts | nindent 20 }}
+              EOF
+              )"
+                fi
+              fi
+          env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          name: init-ssh-known-hosts


### PR DESCRIPTION
**What this PR does / why we need it**:
Added the option to specify a SSH private key used to clone the provided
Git repository.

Also added the possibility for the user to provide an initial set of SSH
known host entries, that will be added to ArgoCD. Similar to the ArgoCD
operator, the provided entries will only be added if the corresponding
ConfigMap does not contain any entries yet. Further modifications after
the initial installation should be done via kubectl/argocd CLI or the
UI.