### PR TITLE
add k8s event logger

### DIFF
--- a/components/logging/k8s-event-logger/README.md
+++ b/components/logging/k8s-event-logger/README.md
@@ -1,0 +1,4 @@
+# K8s event logger 
+K8s event logger puts all the k8s events in the cluster as logs. The log collector(for example promtail) running in the cluster can collect these logs and push them to the log store(for example loki) where they can be stored and used for debugging/monitoring purposes.
+
+Source - https://github.com/max-rocket-internet/k8s-event-logger

--- a/components/logging/k8s-event-logger/k8s-event-logger.yaml
+++ b/components/logging/k8s-event-logger/k8s-event-logger.yaml
@@ -1,0 +1,63 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: k8s-event-logger
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: k8s-event-logger
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+
+---
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: k8s-event-logger
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: k8s-event-logger
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: k8s-event-logger
+  labels:
+    app.kubernetes.io/name: k8s-event-logger
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-event-logger
+subjects:
+- kind: ServiceAccount
+  name: k8s-event-logger
+  namespace: kube-system
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-event-logger
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: k8s-event-logger
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: k8s-event-logger
+    spec:
+      containers:
+        - name: k8s-event-logger
+          image: maxrocketinternet/k8s-event-logger:1.5
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+      serviceAccountName: k8s-event-logger


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds k8s event logger addon which allows us to log all the events happening in the k8s cluster.