### PR TITLE
Added uuid-runtime for uuidgen command support

### DIFF
--- a/helper/kubeone-tool-container/Dockerfile
+++ b/helper/kubeone-tool-container/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update && apt-get install -y\
         netcat \
         dnsutils\
         zsh \
+        uuid-runtime \
         && apt-get clean
 
 


### PR DESCRIPTION
Install uuid-runtime to support the command `uuidgen -r` for UUID generation for telemetry uuid configuration as part of KKP values.yaml, 



Signed-off-by: archups <archupsawant@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Fixed issued
```
bash: uuidgen: command not found
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
