### PR TITLE
Matched terraform provider details to those configured in the version.tf in kubeone terraform examples to fix the terraform init issue

### DIFF
--- a/helper/kubeone-tool-container/terraform_libraries.tf
+++ b/helper/kubeone-tool-container/terraform_libraries.tf
@@ -1,22 +1,30 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.25"
+      source  = "hashicorp/aws"
+      version = "~> 3.45.0"
     }
     google = {
-      version = "~> 4.31"
+      source  = "hashicorp/google"
+      version = "~> 3.71.0"
     }
     vsphere = {
-      version = "~> 1.2"
+      source  = "hashicorp/vsphere"
+      version = "~> 2.0.1"
     }
     azurerm = {
-      version = "~> 3.17"
+      source  = "hashicorp/azurerm"
+      version = "~> 2.63.0"
     }
     helm = {
       version = "~> 2.6"
     }
     null = {
       version = "~> 3.0"
+    }
+    random = {
+      version = "~> 3.3.2"
+      source  = "hashicorp/random"
     }
     tls = {
       version = "~> 3.1"


### PR DESCRIPTION
- One of the reference provider error log for reference

```
Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/random: provider
│ registry.terraform.io/hashicorp/random was not found in any of the search locations
│
│   - /home/kubermatic/.terraform.d/plugins/linux_amd64/providers
```

Signed-off-by: archups <archupsawant@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
```
