### PR TITLE
Extend rclone S3 syncer for other settings types

### DIFF
--- a/components/rclone-s3-syncer/templates/target-secret.yaml
+++ b/components/rclone-s3-syncer/templates/target-secret.yaml
@@ -7,8 +7,21 @@ metadata:
 type: Opaque
 data:
   RCLONE_CONFIG_TARGET_TYPE: {{ default "s3" $job.target.type | b64enc | quote }}
+  {{- if $job.target.account }}
   RCLONE_CONFIG_TARGET_ACCOUNT: {{ default "minio" $job.target.account | b64enc | quote }}
-  RCLONE_CONFIG_TARGET_KEY: {{ default "https://s3.amazonaws.com" $job.target.key | b64enc | quote }}
+  {{- end }}
+  {{- if $job.target.key }}
+  RCLONE_CONFIG_TARGET_KEY: {{ default "" $job.target.key | b64enc | quote }}
+  {{- end }}
+  {{- if $job.target.endpoint }}
+  RCLONE_CONFIG_TARGET_ENDPOINT: {{ default "https://s3.amazonaws.com" $job.target.endpoint | b64enc | quote }}
+  {{- end }}
+  {{- if $job.target.accessKeyID }}
+  RCLONE_CONFIG_TARGET_ACCESS_KEY_ID: {{ default "" $job.target.accessKeyID | b64enc | quote }}
+  {{- end }}
+  {{- if $job.target.secretAccessKey }}
+  RCLONE_CONFIG_TARGET_SECRET_ACCESS_KEY: {{ default "" $job.target.secretAccessKey | b64enc | quote }}
+  {{- end }}
   TARGET_BUCKET: {{ default "minio" $job.target.bucket | b64enc | quote }}
 ---
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows for the rclone-s3-syncer to be used with general S3 settings.

