### PR TITLE
Fix node label toleration for control-plane

### DIFF
--- a/kubermatic-addons/custom-addon/nfs/nfs-csi-driver.yaml
+++ b/kubermatic-addons/custom-addon/nfs/nfs-csi-driver.yaml
@@ -199,7 +199,7 @@ spec:
         key: node-role.kubernetes.io/master
         operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/controlplane
+        key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - hostPath:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: This fixes the wrong naming for node-role toleration to prevent the Kubernetes 1.24 upgrades on KubeOne:

```
ERRO[13:13:51 UTC] Found 2 pod(s) that have toleration removed in Kubernetes 1.24 
"node-role.kubernetes.io/master", but not "node-role.kubernetes.io/control-plane" 
toleration: [csi-nfs-controller-d6dffc647-bmhn8 csi-nfs-controller-d6dffc647-w5wsk]
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: 

**Does this PR introduce a user-facing change?**: No
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
```
