### PR TITLE
Fix batch/v1beta1 deprecated

### DIFF
--- a/components/rclone-s3-syncer/templates/cronjob.yaml
+++ b/components/rclone-s3-syncer/templates/cronjob.yaml
@@ -1,6 +1,10 @@
 {{- range $job := $.Values.rcloneS3Syncer.job }}
 ---
+{{- if .Capabilities.APIVersions.Has "batch/v1beta1/CronJob" }}
 apiVersion: batch/v1beta1
+{{- else }}
+apiVersion: batch/v1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ $job.name }}


### PR DESCRIPTION

Enhanced `s3-syncer` deployment to support both `batch/v1beta1` and `batch/v1` API versions for CronJobs, ensuring compatibility with Kubernetes clusters v1.21 and above.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I used the community-components submodule to deploy `s3-syncer` on cluster v1.28. I found batch/v1beta is deprecated. So I went with batch/v1. 

We can use Helm's `Capabilities.APIVersions.Has` feature to support both apiVersions to deploy them on any kubernetes version

**Does this PR introduce a user-facing change?**:

```release-note
```
