### PR TITLE
Update kubeone-tooling image to 1.7.3

### DIFF
--- a/container/kubeone-tool-container/Dockerfile
+++ b/container/kubeone-tool-container/Dockerfile
@@ -28,34 +28,34 @@ ENV GO111MODULE on
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y\
-        bash-completion \
-        python3-crcmod \
-        ca-certificates \
-        curl \
-        apt-transport-https \
-        lsb-release \
-        gnupg \
-        unzip \
-        upx-ucl \
-        openssh-server \
-        sudo \
-        vim \
-        make \
-        git-crypt \
-        git \
-        fonts-powerline \
-        tmux \
-        software-properties-common \
-        iputils-ping \
-        locate \
-        netcat \
-        dnsutils\
-        zsh \
-        uuid-runtime \
-        iperf3 \
-        fio \
-        figlet lolcat \
-        && apt-get clean
+    bash-completion \
+    python3-crcmod \
+    ca-certificates \
+    curl \
+    apt-transport-https \
+    lsb-release \
+    gnupg \
+    unzip \
+    upx-ucl \
+    openssh-server \
+    sudo \
+    vim \
+    make \
+    git-crypt \
+    git \
+    fonts-powerline \
+    tmux \
+    software-properties-common \
+    iputils-ping \
+    locate \
+    netcat \
+    dnsutils\
+    zsh \
+    uuid-runtime \
+    iperf3 \
+    fio \
+    figlet lolcat \
+    && apt-get clean
 
 RUN wget --no-check-certificate -qO -  https://apt.releases.hashicorp.com/gpg | apt-key add - && \
     apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
@@ -65,22 +65,22 @@ RUN terraform -install-autocomplete
 
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
-unzip awscliv2.zip && \
-./aws/install
+    unzip awscliv2.zip && \
+    ./aws/install
 
 # Install Azure CLI
 RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | \
-         gpg --dearmor | \
-          tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null  && \
-         AZ_REPO=$(lsb_release -cs) && \
-         echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | \
-              tee /etc/apt/sources.list.d/azure-cli.list  && \
-         apt-get update -y && \
-         apt-get install azure-cli -y && \
-         apt-get clean
+    gpg --dearmor | \
+    tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null  && \
+    AZ_REPO=$(lsb_release -cs) && \
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | \
+    tee /etc/apt/sources.list.d/azure-cli.list  && \
+    apt-get update -y && \
+    apt-get install azure-cli -y && \
+    apt-get clean
 
 # Install GCP CLI
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list &&  \
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list &&  \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - &&  \
     apt-get update -y && \
     apt-get install google-cloud-sdk -y && \
@@ -91,8 +91,8 @@ RUN curl -L $(curl -s https://api.github.com/repos/vmware/govmomi/releases/lates
     chmod +x /usr/local/bin/govc
 
 # Install Kubectl & Helm & and fubectl depedencies
-RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
+RUN echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.27/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list && \
+    mkdir -p /etc/apt/keyrings && curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.27/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg && \
     #helm
     curl -s https://baltocdn.com/helm/signing.asc | sudo apt-key add - && \
     echo "deb https://baltocdn.com/helm/stable/debian/ all main" | tee  -a /etc/apt/sources.list.d/helm-stable-debian.list && \
@@ -102,8 +102,8 @@ RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add 
 
 # Install Yq
 RUN RELEASE_URL=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/mikefarah/yq/releases/latest) && \
- YQ_LATEST="${RELEASE_URL##*/}" && \
- wget https://github.com/mikefarah/yq/releases/download/$YQ_LATEST/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq
+    YQ_LATEST="${RELEASE_URL##*/}" && \
+    wget https://github.com/mikefarah/yq/releases/download/$YQ_LATEST/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq
 
 # Install velero
 RUN mkdir /tmp/velero-inst && cd /tmp/velero-inst \
@@ -114,28 +114,28 @@ RUN mkdir /tmp/velero-inst && cd /tmp/velero-inst \
 # Install KubeOne
 ARG kubeone_version
 RUN VERSION=$kubeone_version && \
- curl -LO "https://github.com/kubermatic/kubeone/releases/download/v${VERSION}/kubeone_${VERSION}_linux_amd64.zip" && \
- unzip kubeone_${VERSION}_linux_amd64.zip -d kubeone_${VERSION}_linux_amd64 && \
- mv kubeone_${VERSION}_linux_amd64/kubeone /usr/local/bin
+    curl -LO "https://github.com/kubermatic/kubeone/releases/download/v${VERSION}/kubeone_${VERSION}_linux_amd64.zip" && \
+    unzip kubeone_${VERSION}_linux_amd64.zip -d kubeone_${VERSION}_linux_amd64 && \
+    mv kubeone_${VERSION}_linux_amd64/kubeone /usr/local/bin
 
 # Install kustomize
 RUN curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash && \
- mv kustomize /usr/local/bin
+    mv kustomize /usr/local/bin
 
 # Install Sops
 RUN SOPS_VERSION=$(curl -w '%{url_effective}' -I -L -s -S https://github.com/mozilla/sops/releases/latest -o /dev/null | sed -e 's|.*/v||') && \
- curl -LO https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux && \
- install -o root -g root -m 0755 sops-v${SOPS_VERSION}.linux /usr/local/bin/sops
+    curl -LO https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux && \
+    install -o root -g root -m 0755 sops-v${SOPS_VERSION}.linux /usr/local/bin/sops
 
 # Install k9s
 RUN K9S_RELEASE_URL=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/derailed/k9s/releases/latest) && \
- K9S_LATEST="${K9S_RELEASE_URL##*/}" && \
- wget -c "https://github.com/derailed/k9s/releases/download/${K9S_LATEST}/k9s_Linux_amd64.tar.gz"  -O - | tar -xz -C /usr/local/bin/
+    K9S_LATEST="${K9S_RELEASE_URL##*/}" && \
+    wget -c "https://github.com/derailed/k9s/releases/download/${K9S_LATEST}/k9s_Linux_amd64.tar.gz"  -O - | tar -xz -C /usr/local/bin/
 
 RUN CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt) && \
-curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-${OS}-${ARCH}.tar.gz && \
-sudo tar -C /usr/local/bin -xzvf cilium-${OS}-${ARCH}.tar.gz && \
-rm cilium-${OS}-${ARCH}.tar.gz
+    curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-${OS}-${ARCH}.tar.gz && \
+    sudo tar -C /usr/local/bin -xzvf cilium-${OS}-${ARCH}.tar.gz && \
+    rm cilium-${OS}-${ARCH}.tar.gz
 
 # Install LazyGit
 RUN LAZYGIT_VERSION=0.37.0 && \

--- a/container/kubeone-tool-container/Makefile
+++ b/container/kubeone-tool-container/Makefile
@@ -1,5 +1,5 @@
 ## See https://github.com/kubermatic/kubeone/releases
-KUBEONE_VERSION ?= 1.7.2
+KUBEONE_VERSION ?= 1.7.3
 DOCKER_REPO ?= 'quay.io/kubermatic-labs/kubeone-tooling'
 FINAL_TAG ?= ${KUBEONE_VERSION}
 TAG_DATE ?= ${KUBEONE_VERSION}-$(shell date -I)

--- a/container/kubeone-tool-container/terraform_libraries.tf
+++ b/container/kubeone-tool-container/terraform_libraries.tf
@@ -2,19 +2,19 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.45.0"
+      version = "~> 4.1.0"
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.71.0"
+      version = "~> 4.27.0"
     }
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = "~> 2.0.1"
+      version = "~> 2.1.1"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.63.0"
+      version = "~> 3.10.0"
     }
     helm = {
       version = "~> 2.6"
@@ -36,6 +36,10 @@ terraform {
     openstack = {
       source = "terraform-provider-openstack/openstack"
       version = "1.47.0"
+    }
+    time = {
+      source = "hashicorp/time"
+      version = "0.11.1"
     }
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR will update the kubeone-tooling container image to 1.7.3
- kubeone version update from 1.7.2 to 1.7.3
- Replace the legacy k8s packages as per https://github.com/kubernetes/release/issues/3485
`apt.kubernetes.io` is not a thing any longer, we have to use `pkgs.k8s.io instead` Checkout the [deprecation announcement](https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/).
- Updated the  terraform  provider library - version updates for azure, google , aws and vsphere
- Add time provider to the terraform provider library

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
