### PR TITLE
Update kubeone-tooling image  to 1.8.0

### DIFF
--- a/container/kubeone-tool-container/Makefile
+++ b/container/kubeone-tool-container/Makefile
@@ -1,5 +1,5 @@
 ## See https://github.com/kubermatic/kubeone/releases
-KUBEONE_VERSION ?= 1.7.4
+KUBEONE_VERSION ?= 1.8.0
 DOCKER_REPO ?= 'quay.io/kubermatic-labs/kubeone-tooling'
 FINAL_TAG ?= ${KUBEONE_VERSION}
 TAG_DATE ?= ${KUBEONE_VERSION}-$(shell date -I)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR is to upgrade the kubeone to latest minor release version 1.8.0 in the kubeone-tooling container image to address the latest Ubuntu cloud-init fix with OSM bump. https://github.com/kubermatic/kubeone/pull/3172

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
```
