### PR TITLE
check if velero crd directory exists

### DIFF
--- a/helper/kubermatic-installer-script/kubermatic-deploy.sh
+++ b/helper/kubermatic-installer-script/kubermatic-deploy.sh
@@ -92,7 +92,9 @@ function deployBackup() {
       deploy    minio minio minio/
       deploy    s3-exporter kube-system s3-exporter/
     fi
-    kubectl apply -f "$CHART_FOLDER/backup/velero/crd"
+    if [[ -d "$CHART_FOLDER/backup/velero/crd" ]]; then
+      kubectl apply -f "$CHART_FOLDER/backup/velero/crd"
+    fi
     deploy velero velero backup/velero
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The custom velero chart is replaced with v2.26 and `charts/backup/velero/crd` directory does not exist anymore. Added a control if the directory is there to run the kubectl command, previous KKP versions should work fine.

Otherwise `deployBackup()` fails on v2.26.

